### PR TITLE
[FEAT] APIKey 핸들링위한 xcconfig파일 추가 

### DIFF
--- a/Vegeting.xcodeproj/project.pbxproj
+++ b/Vegeting.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		4A31CD232903D73D00E5E422 /* FirstCreateGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstCreateGroupViewController.swift; sourceTree = "<group>"; };
 		4A31CD262903D86200E5E422 /* GroupCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCategoryView.swift; sourceTree = "<group>"; };
 		4A31CD292903D89600E5E422 /* GroupCategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCategoryCollectionViewCell.swift; sourceTree = "<group>"; };
+		4A50D5A929094D8900D1ADE4 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		4ADC12DC2901800D00C0FFB6 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		4ADC12E02901813900C0FFB6 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		4ADC12E22901815C00C0FFB6 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
@@ -161,6 +162,7 @@
 				A7C8DF232901274500F38AD7 /* AppDelegate.swift */,
 				76B02828290520BB002C9DF7 /* GoogleService-Info.plist */,
 				A7C8DF252901274500F38AD7 /* SceneDelegate.swift */,
+				4A50D5A929094D8900D1ADE4 /* Secret.xcconfig */,
 			);
 			path = Supports;
 			sourceTree = "<group>";
@@ -614,6 +616,7 @@
 		};
 		A7C8DF352901274600F38AD7 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A50D5A929094D8900D1ADE4 /* Secret.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -647,6 +650,7 @@
 		};
 		A7C8DF362901274600F38AD7 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A50D5A929094D8900D1ADE4 /* Secret.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Vegeting/Global/Literals/StringLiteral.swift
+++ b/Vegeting/Global/Literals/StringLiteral.swift
@@ -10,5 +10,5 @@ import Foundation
 enum StringLiteral {
     
     static let exampleString = "안녕하세요"
-    
+    static let kakaoAPIKey = Bundle.main.object(forInfoDictionaryKey: "API_KEY")
 }

--- a/Vegeting/Global/Supports/Info.plist
+++ b/Vegeting/Global/Supports/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>API_KEY</key>
+	<string>$(API_KEY)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Vegeting/Global/Supports/Secret.xcconfig
+++ b/Vegeting/Global/Supports/Secret.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Secret.xcconfig
+//  Vegeting
+//
+//  Created by 최동권 on 2022/10/26.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+API_KEY = test


### PR DESCRIPTION
## 🌱 관련 이슈
- Close #47 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🌱 구현/변경 사항 및 이유
- APIKey값이 레포에 노출되지 않게 하기 위해서 xcconfig 파일을 만들었습니다. 해당 파일에는 아무내용도 담겨있지 않고 각각의 컴퓨터에서 kaokao 키를 직접 입력하여 호출하시면 됩니다.
- xcconfig파일에 키가 추가된 다음에 실수로 레포에 올라오는 불상사를 막기위해 각자의 terminal에서 설정을 해주어야 합니다.
`git update-index --assume-unchanged Secret.xcconfig`을 해주면 됩니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🌱 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🌱 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
