### PR TITLE
[FEAT]: Github Action Swift Package manager Caching 구현

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,4 +24,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
       - name: Set Scheme and Build Xcode 
-        run: xcodebuild test -project Vegeting.xcodeproj -scheme "Vegeting" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=16.0" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+        run: xcodebuild test -project Vegeting.xcodeproj -scheme "Vegeting" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=16.1" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select Xcode Verson
-        run: sudo xcode-select -s '/Applications/Xcode_13.2.app//Contents/Developer'
-      - name: Swift Package Manager caching
+        run: sudo xcode-select -s '/Applications/Xcode_14.1.app//Contents/Developer'
+      - name: Swift Package Manager caches
         uses: actions/cache@v3
         with: 
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }} 
           restore-keys: |
             ${{ runner.os }}-spm-
-      - name: Set Default Scheme
-        run: xcodebuild test -project Vegeting.xcodeproj -scheme "Vegeting" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=15.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+      - name: Set Scheme and Build Xcode 
+        run: xcodebuild test -project Vegeting.xcodeproj -scheme "Vegeting" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=16.0" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,5 +16,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Select Xcode Verson
         run: sudo xcode-select -s '/Applications/Xcode_13.2.app//Contents/Developer'
+      - name: Swift Package Manager caching
+        uses: actions/cache@v3
+        with: 
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Set Default Scheme
         run: xcodebuild test -project Vegeting.xcodeproj -scheme "Vegeting" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=15.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
-Package.resolved
+# Package.resolved
 # *.xcodeproj
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project

--- a/Vegeting.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vegeting.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,140 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "state" : {
+        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
+        "version" : "0.20220203.2"
+      }
+    },
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
+      }
+    },
+    {
+      "identity" : "boringssl-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "state" : {
+        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
+      }
+    },
+    {
+      "identity" : "grpc-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-ios.git",
+      "state" : {
+        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
+        "version" : "1.44.3-grpc"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "c503b3b0f60bf1b788cc3e71eab28648a838861c"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
+      }
+    },
+    {
+      "identity" : "swiftyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",
+      "state" : {
+        "revision" : "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
+        "version" : "5.0.1"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #160 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🌱 구현/변경 사항 및 이유
- Swift Package Manager caching을 위해 yml 파일을 수정했습니다.
- Github Action은 unique key를 통해서 캐쉬들을 생성하고 생성된 캐쉬들을 복원시킵니다.    

### Github Action Cache 설명
- Cache 접근에 제한사항
- 이때, 특정 브랜치에서 만들어진 cache에 접근하는데는 제한이 생깁니다.(같은 repository라고 전부 접근할 수 없습니다.) 
- 만약 feature-b라는 브랜치가 존재하고, 해당 브랜치의 base branch는 feature-a라고 가정할게요.
- 그렇다면 해당 브랜치의 PR에서 만들어진 캐쉬는 는 feature-b, feature-a, default branch(우리는 develop에 해당)에서 캐쉬 접근이 가능합니다.    
- 하지만 child or sibling branch들의 경우는 접근이 불가능합니다. (예를들어, develop branch는 feature-b에서 생성된 캐시를 restore 시키는게 가능하지만, feature-b가 develop껄 restore시키는 건 불가능합니다.) 

### yml file 설명
1. keys 
cache들은 기본적으로 우리가 제공한 key로부터 github aciton이 cache restore을 시도합니다.(우리가 제공한 key를 통해서 캐쉬를 찾는 것)
이때 action에서 key와 매칭됐다고 판단한다면, 우리가 지정한 path에 cached file들을 복원시킵니다. (찾았다면, build path에 복원시켜 줍니다.)
2. restore- keys
해당 restore 키들의 역할은 만약 "key"와 매칭되는 캐쉬가 없다면, restore키를 통해 캐쉬 액션이 restore key들의 목록중 매칭되는 키들을 searching한다. 
3. 만약 존재한다면 캐쉬에 파일들을 path directory에 복원시켜준다. 
4. 만약 존재하지 않는다면 action은 restore key들과 부분적인 matching을 찾아보고 만약 찾았다면 가장 최근 캐쉬를 path directory에 복원시켜 준다. 
## 🌱 PR Point
- yml file확인 부탁드려요!
- 다들 너무 원하시는 spm 빌드 타임 축소를 적용해봤어요. 신속한 approve 부탁드립니다. 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
## ⚠️주의사항
1. 해당 파일에서, gitignore가 수정됩니다. 반드시 gitignore가 수정되는 걸 숙지해주세요
2. gitignore가 사라지고 나면, git rm -r --cached 명령어를 입력해주세요.
3. 해당 명령어를 입력하는 목적은 기존의 ignore cache를 날리고, 새롭게 생긴 ignore를 적용하기 위함입니다. 
4. Xcode 14.1로 version 통일이 완료되어야 합니다.
5. 해당 swift package들이 14.1을 기준으로 받았기 때문에, 해당 버전과 일치하지 않으면 action fail이 날 수 있습니다.


## 참고 사이트
https://github.com/actions/cache/blob/main/examples.md#swift---swift-package-manager
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows

Cannot input key founds에 대한 에러 원인 분석을 위해 찾은 사이트 
https://github.com/actions/toolkit/issues/658