### PR TITLE
[FEAT]: 마감된 모임은 마지막에 보여주도록 api 수정 

### DIFF
--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -48,7 +48,7 @@ final class FirebaseManager {
                 try? snapshot.data(as: Club.self)
             }
             data.forEach { club in
-                if club.participants?.count ?? 0 < club.maxNumberOfPeople || Date() >= club.dateToMeet {
+                if club.participants?.count ?? 0 < club.maxNumberOfPeople || Date() < club.dateToMeet {
                     validClubs.append(club)
                 } else {
                     invalidClubs.append(club)

--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -48,7 +48,7 @@ final class FirebaseManager {
                 try? snapshot.data(as: Club.self)
             }
             data.forEach { club in
-                if club.participants?.count ?? 0 < club.maxNumberOfPeople || Date() < club.dateToMeet {
+                if club.participants?.count ?? 0 < club.maxNumberOfPeople && Date() < club.dateToMeet {
                     validClubs.append(club)
                 } else {
                     invalidClubs.append(club)

--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -48,7 +48,7 @@ final class FirebaseManager {
                 try? snapshot.data(as: Club.self)
             }
             data.forEach { club in
-                if club.participants?.count ?? 0 < club.maxNumberOfPeople {
+                if club.participants?.count ?? 0 < club.maxNumberOfPeople || Date() >= club.dateToMeet {
                     validClubs.append(club)
                 } else {
                     invalidClubs.append(club)

--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -44,8 +44,10 @@ final class FirebaseManager {
             var validClubs = [Club]()
             var invalidClubs = [Club]()
             let querySnapshot = try await db.collection(Path.club.rawValue).getDocuments()
-            querySnapshot.documents.forEach { snapshot in
-                guard let club = try? snapshot.data(as: Club.self) else { return }
+            let data = querySnapshot.documents.compactMap { snapshot in
+                try? snapshot.data(as: Club.self)
+            }
+            data.forEach { club in
                 if club.participants?.count ?? 0 < club.maxNumberOfPeople {
                     validClubs.append(club)
                 } else {

--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -41,11 +41,18 @@ final class FirebaseManager {
     /// - Returns: 모든 클럽 정보가 나타난다.
     func requestClubInformation() async -> [Club]? {
         do {
+            var validClubs = [Club]()
+            var invalidClubs = [Club]()
             let querySnapshot = try await db.collection(Path.club.rawValue).getDocuments()
-            let data = querySnapshot.documents.compactMap { snapshot in
-                try? snapshot.data(as: Club.self)
+            querySnapshot.documents.forEach { snapshot in
+                guard let club = try? snapshot.data(as: Club.self) else { return }
+                if club.participants?.count ?? 0 < club.maxNumberOfPeople {
+                    validClubs.append(club)
+                } else {
+                    invalidClubs.append(club)
+                }
             }
-            return data
+            return validClubs + invalidClubs
         } catch {
             print(error.localizedDescription)
             return nil


### PR DESCRIPTION
## 🌱 관련 이슈
- close #169
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🌱 구현/변경 사항 및 이유
### 1. 현재 마감된 모임이 중간중간에 섞여서 보이고 있는데, 마감된 모임은 마지막에 보여주도록 한다.

```swift 
func requestClubInformation() async -> [Club]? {
        do {
            var validClubs = [Club]()
            var invalidClubs = [Club]()
            let querySnapshot = try await db.collection(Path.club.rawValue).getDocuments()
            querySnapshot.documents.forEach { snapshot in
                guard let club = try? snapshot.data(as: Club.self) else { return }
                if club.participants?.count ?? 0 < club.maxNumberOfPeople {
                    validClubs.append(club)
                } else {
                    invalidClubs.append(club)
                }
            }
            return validClubs + invalidClubs
        } catch {
            print(error.localizedDescription)
            return nil
        }
    }
```
1. 클럽을 파베에서 불러온 뒤, 마감됐는지 판단하기 위한 `if club.participants?.count ?? 0 < club.maxNumberOfPeople` 조건문을 통해 판단한 뒤,
2. 마감된 모임이면 validClubs 배열에 넣어주고
3. 마감되지 않은 모임이면 validClubs 배열에 넣어줍니다
4. 마지막으로 validClubs + validClubs를 리턴해주는 로직입니다.

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🌱 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🌱 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
