### PR TITLE
[FEAT]: 닉네임 중복 체크 적용, 회원탈퇴 기능

### DIFF
--- a/Vegeting.xcodeproj/project.pbxproj
+++ b/Vegeting.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		76FF7CFA2917BDF70020BB2C /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 76FF7CF92917BDF70020BB2C /* KakaoSDKUser */; };
 		A2007F49291444730003DABB /* SegmentedControlCustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2007F48291444730003DABB /* SegmentedControlCustomView.swift */; };
 		A2007F4C2914BF5D0003DABB /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2007F4B2914BF5D0003DABB /* CategoryView.swift */; };
+		A203AB49293675B0008CB260 /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = A203AB48293675B0008CB260 /* Report.swift */; };
 		A20A2F9F29217EC2002F0672 /* MyClubsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20A2F9E29217EC2002F0672 /* MyClubsViewController.swift */; };
 		A215B29929069D9600DD60B2 /* SecondCreateGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A215B29829069D9600DD60B2 /* SecondCreateGroupViewController.swift */; };
 		A215B29C2906DB6400DD60B2 /* PhotoPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A215B29B2906DB6400DD60B2 /* PhotoPickerView.swift */; };
@@ -194,6 +195,7 @@
 		76E9EC3D2919C9FC00193B1C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A2007F48291444730003DABB /* SegmentedControlCustomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCustomView.swift; sourceTree = "<group>"; };
 		A2007F4B2914BF5D0003DABB /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
+		A203AB48293675B0008CB260 /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
 		A20A2F9E29217EC2002F0672 /* MyClubsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyClubsViewController.swift; sourceTree = "<group>"; };
 		A215B29829069D9600DD60B2 /* SecondCreateGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondCreateGroupViewController.swift; sourceTree = "<group>"; };
 		A215B29B2906DB6400DD60B2 /* PhotoPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerView.swift; sourceTree = "<group>"; };
@@ -648,6 +650,7 @@
 				76548E2D291AB11700418994 /* RecentChat.swift */,
 				4AFF0F56291AA5CE00F7496C /* MyPageSettingElement.swift */,
 				A7970135292CA1A0007BF519 /* VegetarianTypeDescription.swift */,
+				A203AB48293675B0008CB260 /* Report.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -888,6 +891,7 @@
 			files = (
 				4AB5C27C2907A9CE0064C41E /* Place.swift in Sources */,
 				76548E2E291AB11700418994 /* RecentChat.swift in Sources */,
+				A203AB49293675B0008CB260 /* Report.swift in Sources */,
 				4ADC12E32901815C00C0FFB6 /* UIViewController+Extension.swift in Sources */,
 				4ADC12E12901813900C0FFB6 /* NSObject+Extension.swift in Sources */,
 				A76096422908ACA900636A99 /* ProfileCollectionViewCell.swift in Sources */,

--- a/Vegeting.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vegeting.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,149 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "state" : {
+        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
+        "version" : "0.20220203.2"
+      }
+    },
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
+      }
+    },
+    {
+      "identity" : "boringssl-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "state" : {
+        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
+      }
+    },
+    {
+      "identity" : "grpc-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-ios.git",
+      "state" : {
+        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
+        "version" : "1.44.3-grpc"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "branch" : "master",
+        "revision" : "c503b3b0f60bf1b788cc3e71eab28648a838861c"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher",
+      "state" : {
+        "revision" : "44e891bdb61426a95e31492a67c7c0dfad1f87c5",
+        "version" : "7.4.1"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
+      }
+    },
+    {
+      "identity" : "swiftyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",
+      "state" : {
+        "revision" : "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
+        "version" : "5.0.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Vegeting/Global/Extensions/UIColor+Extension.swift
+++ b/Vegeting/Global/Extensions/UIColor+Extension.swift
@@ -19,7 +19,7 @@ extension UIColor {
     static let vfGray4 = UIColor(hex: "#F2F2F2")
     
     static let vfBlack = UIColor(hex: "#333333")
-    static let vfGreend = UIColor(hex: "#24A869")
+    static let vfGreen = UIColor(hex: "#24A869")
     static let vfRed = UIColor(hex: "#ED4E4E")
     
 }

--- a/Vegeting/Global/Extensions/UIStackView+Extention.swift
+++ b/Vegeting/Global/Extensions/UIStackView+Extention.swift
@@ -11,6 +11,7 @@ extension UIStackView {
 
     func addArrangedSubviews (_ views: UIView...) {
         views.forEach { [weak self] view in
+            view.translatesAutoresizingMaskIntoConstraints = false
             self?.addArrangedSubview(view)
         }
     }

--- a/Vegeting/Global/Extensions/UITextField+Extension.swift
+++ b/Vegeting/Global/Extensions/UITextField+Extension.swift
@@ -16,7 +16,7 @@ extension UITextField {
     
     func underlined(color: UIColor) {
         let border = CALayer()
-        border.frame = CGRect(x: 0, y: self.frame.size.height-1,
+        border.frame = CGRect(x: 0, y: self.frame.size.height,
                               width: self.frame.width, height: 2)
         border.backgroundColor = color.cgColor
         self.layer.addSublayer(border)

--- a/Vegeting/Global/Extensions/UITextField+Extension.swift
+++ b/Vegeting/Global/Extensions/UITextField+Extension.swift
@@ -13,4 +13,12 @@ extension UITextField {
         self.leftView = paddingView
         self.leftViewMode = ViewMode.always
     }
+    
+    func underlined(color: UIColor) {
+        let border = CALayer()
+        border.frame = CGRect(x: 0, y: self.frame.size.height-1,
+                              width: self.frame.width, height: 2)
+        border.backgroundColor = color.cgColor
+        self.layer.addSublayer(border)
+    }
 }

--- a/Vegeting/Global/Extensions/UIViewController+Extension.swift
+++ b/Vegeting/Global/Extensions/UIViewController+Extension.swift
@@ -23,4 +23,12 @@ extension UIViewController {
             NSLayoutConstraint.activate(constraint)
         }
     }
+    
+    func showTabBar() {
+        tabBarController?.tabBar.isHidden = false
+    }
+    
+    func hideTabBar() {
+        tabBarController?.tabBar.isHidden = true
+    }
 }

--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -24,6 +24,7 @@ final class FirebaseManager {
         case club = "Clubs"
         case chat = "Chats"
         case recentChat = "RecentChats"
+        case unregister = "Unregister"
     }
     
     //    TODO: 추후 회원가입을 위한 Model 따로 만들기
@@ -281,6 +282,24 @@ extension FirebaseManager {
         } catch {
             print(error.localizedDescription)
         }
+    }
+    
+    func unregisterUser(reason: [String]) {
+        
+        let reportDocument = db.collection(Path.unregister.rawValue).document()
+        let reason = Report(reason: reason)
+        reportDocument.setData(from: reason)
+        
+        guard let uid = auth.currentUser?.uid else { return }
+        
+        db.collection(Path.user.rawValue).document("aaaa").delete() { err in
+            if let err = err {
+                print("Error removing document: \(err)")
+            } else {
+                print("Document successfully removed!")
+            }
+        }
+        
     }
     
     func requestUser() async -> VFUser? {

--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -285,14 +285,13 @@ extension FirebaseManager {
     }
     
     func unregisterUser(reason: [String]) {
-        
         let reportDocument = db.collection(Path.unregister.rawValue).document()
         let reason = Report(reason: reason)
         reportDocument.setData(from: reason)
         
         guard let uid = auth.currentUser?.uid else { return }
         
-        db.collection(Path.user.rawValue).document("aaaa").delete() { err in
+        db.collection(Path.user.rawValue).document(uid).delete() { err in
             if let err = err {
                 print("Error removing document: \(err)")
             } else {
@@ -300,6 +299,7 @@ extension FirebaseManager {
             }
         }
         
+        auth.currentUser?.delete()
     }
     
     func requestUser() async -> VFUser? {

--- a/Vegeting/Global/Models/Report.swift
+++ b/Vegeting/Global/Models/Report.swift
@@ -1,0 +1,12 @@
+//
+//  Report.swift
+//  Vegeting
+//
+//  Created by kelly on 2022/11/30.
+//
+
+import Foundation
+
+struct Report: Codable {
+    let reason: [String]
+}

--- a/Vegeting/Global/Supports/SceneDelegate.swift
+++ b/Vegeting/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = UserProfileViewController()
+        window.rootViewController = MainTabBarViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/Vegeting/Global/Supports/SceneDelegate.swift
+++ b/Vegeting/Global/Supports/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = MainTabBarViewController()
+        window.rootViewController = UserProfileViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/Vegeting/Screens/ChatRoom/ViewController/ChatRoomListViewController.swift
+++ b/Vegeting/Screens/ChatRoom/ViewController/ChatRoomListViewController.swift
@@ -48,6 +48,16 @@ class ChatRoomListViewController: UIViewController {
         requestUserInfo()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        showTabBar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        hideTabBar()
+    }
+    
     // MARK: - func
     
     private func setupLayout() {

--- a/Vegeting/Screens/CreateGroup/ViewController/FirstCreateGroupViewController.swift
+++ b/Vegeting/Screens/CreateGroup/ViewController/FirstCreateGroupViewController.swift
@@ -137,10 +137,6 @@ final class FirstCreateGroupViewController: UIViewController {
     
     //MARK: - func
     
-    private func hideTabBar() {
-        self.tabBarController?.tabBar.isHidden = true
-    }
-    
     private func setupNavigationBar() {
         self.navigationItem.backButtonDisplayMode = .minimal
     }

--- a/Vegeting/Screens/GroupList/ViewController/GroupListViewController.swift
+++ b/Vegeting/Screens/GroupList/ViewController/GroupListViewController.swift
@@ -90,14 +90,6 @@ class GroupListViewController: UIViewController {
     
     //MARK: - func
     
-    private func showTabBar() {
-        self.tabBarController?.tabBar.isHidden = false
-    }
-    
-    private func hideTabBar() {
-        tabBarController?.tabBar.isHidden = true
-    }
-    
     private func configureUI() {
         view.backgroundColor = .systemBackground
     }

--- a/Vegeting/Screens/MyPage/ViewController/MyClubsViewController.swift
+++ b/Vegeting/Screens/MyPage/ViewController/MyClubsViewController.swift
@@ -76,10 +76,6 @@ class MyClubsViewController: UIViewController {
         view.backgroundColor = .systemBackground
     }
     
-    private func hideTabBar() {
-        tabBarController?.tabBar.isHidden = true
-    }
-    
     private func setupNavigationBar() {
         navigationItem.title = "참여한 모임"
     }

--- a/Vegeting/Screens/MyPage/ViewController/MyPageViewController.swift
+++ b/Vegeting/Screens/MyPage/ViewController/MyPageViewController.swift
@@ -133,9 +133,14 @@ extension MyPageViewController: UITableViewDataSource {
 extension MyPageViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch indexPath.row {
+        // 주최한 모임
         case 1 :
             let viewController = MyClubsViewController()
-            self.navigationController?.pushViewController(viewController, animated: true)
+            navigationController?.pushViewController(viewController, animated: true)
+        // 회원탈퇴
+        case 10:
+            let reportViewController = ReportViewController(entryPoint: .unregister)
+            navigationController?.pushViewController(reportViewController, animated: true)
         default:
             return
         }

--- a/Vegeting/Screens/MyPage/ViewController/MyPageViewController.swift
+++ b/Vegeting/Screens/MyPage/ViewController/MyPageViewController.swift
@@ -64,11 +64,6 @@ class MyPageViewController: UIViewController {
             self?.vfUser = vfUser
         }
     }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        hideTabBar()
-    }
 
     //MARK: - func
     
@@ -82,14 +77,6 @@ class MyPageViewController: UIViewController {
     
     private func configureUI() {
         view.backgroundColor = .white
-    }
-    
-    private func showTabBar() {
-        tabBarController?.tabBar.isHidden = false
-    }
-
-    private func hideTabBar() {
-        tabBarController?.tabBar.isHidden = true
     }
     
     private func setupNavigationBar() {

--- a/Vegeting/Screens/MyPage/ViewController/MyPageViewController.swift
+++ b/Vegeting/Screens/MyPage/ViewController/MyPageViewController.swift
@@ -64,6 +64,11 @@ class MyPageViewController: UIViewController {
             self?.vfUser = vfUser
         }
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        hideTabBar()
+    }
 
     //MARK: - func
     
@@ -81,6 +86,10 @@ class MyPageViewController: UIViewController {
     
     private func showTabBar() {
         tabBarController?.tabBar.isHidden = false
+    }
+
+    private func hideTabBar() {
+        tabBarController?.tabBar.isHidden = true
     }
     
     private func setupNavigationBar() {

--- a/Vegeting/Screens/MyPage/ViewController/MyProfileEditViewController.swift
+++ b/Vegeting/Screens/MyPage/ViewController/MyProfileEditViewController.swift
@@ -26,6 +26,11 @@ class MyProfileEditViewController: UIViewController {
         setupNavigationBar()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        hideTabBar()
+    }
+    
     private func setupLayout() {
         view.addSubviews(profileView, bottomButton)
         

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -64,8 +64,13 @@ final class UserProfileViewController: UIViewController {
         return textField
     }()
     
-    private let validNicknameLabel: UILabel = {
+    private let validImageLabel: UILabel = {
         let label = UILabel()
+        return label
+    }()
+    
+    private let validLabel: UILabel = {
+        let label  = UILabel()
         label.font = .preferredFont(forTextStyle: .footnote)
         return label
     }()
@@ -106,7 +111,7 @@ final class UserProfileViewController: UIViewController {
         view.backgroundColor = .systemBackground
         view.addSubviews(progressBarImageView, profileMessageLabel, profileImageView,
                          nicknameMessageLabel, cameraButton, nicknameTextField,
-                         validNicknameLabel, nicknameTextCountLabel, nextButton)
+                         validImageLabel, validLabel, nicknameTextCountLabel, nextButton)
     }
     
     private func setupLayout() {
@@ -149,8 +154,13 @@ final class UserProfileViewController: UIViewController {
         ])
         
         NSLayoutConstraint.activate([
-            validNicknameLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 10),
-            validNicknameLabel.leadingAnchor.constraint(equalTo: nicknameTextField.leadingAnchor)
+            validImageLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 8.5),
+            validImageLabel.leadingAnchor.constraint(equalTo: nicknameTextField.leadingAnchor),
+        ])
+        
+        NSLayoutConstraint.activate([
+            validLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 10),
+            validLabel.leadingAnchor.constraint(equalTo: nicknameTextField.leadingAnchor, constant: 15),
         ])
         
         NSLayoutConstraint.activate([
@@ -212,19 +222,26 @@ final class UserProfileViewController: UIViewController {
         guard let nickname = nicknameTextField.text else { return }
 
         if nickname.count < 2 {
-            validNicknameLabel.text = "닉네임은 두 글자 이상이어야 합니다."
-            changeButtonStatusAndValidLabel(false)
+            changeButtonStatusAndValidLabel(false, text: " 닉네임은 두 글자 이상이어야 합니다.")
         } else {
             Task { [weak self] in
                 let isPossible = try await FirebaseManager.shared.isPossibleNickname(newName: nickname)
-                self?.validNicknameLabel.text = isPossible ? "사용 가능한 닉네임입니다." : "다른 사용자가 사용 중인 닉네임입니다."
-                self?.changeButtonStatusAndValidLabel(isPossible)
+                self?.changeButtonStatusAndValidLabel(isPossible, text: (isPossible ? " 사용 가능한 닉네임입니다." : " 다른 사용자가 사용 중인 닉네임입니다."))
             }
         }
     }
     
-    private func changeButtonStatusAndValidLabel(_ isPossible: Bool) {
-        validNicknameLabel.textColor = isPossible ? .vfGreen : .vfRed
+    private func changeButtonStatusAndValidLabel(_ isPossible: Bool, text: String) {
+        let imageSize = CGSize(width: 15, height: 15)
+        let textColor = isPossible ? UIColor.vfGreen : UIColor.vfRed
+        
+        let SFSymbolToText = NSTextAttachment()
+        SFSymbolToText.image = UIImage(systemName: (isPossible ? "checkmark.circle.fill" : "exclamationmark.circle.fill"))?.withTintColor(textColor).resize(to: imageSize)
+        validImageLabel.attributedText = NSAttributedString(attachment: SFSymbolToText)
+    
+        validLabel.text = text
+        validLabel.textColor = textColor
+        
         nextButton.isEnabled = isPossible
     }
     

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -56,9 +56,11 @@ final class UserProfileViewController: UIViewController {
         return label
     }()
     
-    private let nicknameTextField: UITextField = {
+    private lazy var nicknameTextField: UITextField = {
         let textField = UITextField()
         textField.borderStyle = .none
+        textField.delegate = self
+        textField.addTarget(self, action: #selector(textDidChangeForLabel), for: .editingChanged)
         return textField
     }()
     
@@ -77,10 +79,9 @@ final class UserProfileViewController: UIViewController {
         return button
     }()
     
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        configureTextField()
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        nicknameTextField.underlined(color: .vfGray4)
     }
     
     override func viewDidLoad() {
@@ -88,17 +89,6 @@ final class UserProfileViewController: UIViewController {
         
         configureUI()
         setupLayout()
-    }
-    
-    private func configureTextField() {
-        let border = CALayer()
-        border.frame = CGRect(x: 0, y: nicknameTextField.frame.size.height-1,
-                              width: nicknameTextField.frame.width, height: 1)
-        border.backgroundColor = UIColor(hex: "#F2F2F2").cgColor
-        nicknameTextField.layer.addSublayer(border)
-        nicknameTextField.delegate = self
-        
-        nicknameTextField.addTarget(self, action: #selector(textDidChangeForLabel), for: .editingChanged)
     }
     
     private func configureUI() {
@@ -181,6 +171,7 @@ final class UserProfileViewController: UIViewController {
     
     @objc
     private func textDidChangeForLabel() {
+        print("textDidChangeForLabel")
         guard let text = nicknameTextField.text else { return }
         var textLength = text.count
         
@@ -227,6 +218,16 @@ extension UserProfileViewController: UITextFieldDelegate {
             return false
         }
         return true
+    }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        print("begin")
+        configureTextField(lineColor: .vfYellow1)
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        print("end")
+        configureTextField(lineColor: .vfGray4)
     }
 }
 

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -64,6 +64,12 @@ final class UserProfileViewController: UIViewController {
         return textField
     }()
     
+    private let validNicknameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .footnote)
+        return label
+    }()
+    
     private let nicknameTextCountLabel: UILabel = {
         let label = UILabel()
         label.textColor = .vfGray3
@@ -100,7 +106,7 @@ final class UserProfileViewController: UIViewController {
         view.backgroundColor = .systemBackground
         view.addSubviews(progressBarImageView, profileMessageLabel, profileImageView,
                          nicknameMessageLabel, cameraButton, nicknameTextField,
-                         nicknameTextCountLabel, nextButton)
+                         validNicknameLabel, nicknameTextCountLabel, nextButton)
     }
     
     private func setupLayout() {
@@ -139,11 +145,16 @@ final class UserProfileViewController: UIViewController {
             nicknameTextField.topAnchor.constraint(equalTo: nicknameMessageLabel.bottomAnchor, constant: 17),
             nicknameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             nicknameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            nicknameTextField.heightAnchor.constraint(equalToConstant: 50)
+            nicknameTextField.heightAnchor.constraint(equalToConstant: 35)
         ])
         
         NSLayoutConstraint.activate([
-            nicknameTextCountLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 13),
+            validNicknameLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 10),
+            validNicknameLabel.leadingAnchor.constraint(equalTo: nicknameTextField.leadingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            nicknameTextCountLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 10),
             nicknameTextCountLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
         ])
         

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -89,6 +89,11 @@ final class UserProfileViewController: UIViewController {
         
         configureUI()
         setupLayout()
+        hideKeyboardWhenTappedAround()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     private func configureUI() {

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -204,12 +204,28 @@ final class UserProfileViewController: UIViewController {
             textLength = newString.count
         }
         
-        changeButtonStatus(textLength: textLength)
+        validateNickname()
         configureTextCountLabel(textLength: textLength)
     }
     
-    private func changeButtonStatus(textLength: Int) {
-        textLength < nicknameMinLength ? nextButtonInactive() : nextButtonActive()
+    private func validateNickname() {
+        guard let nickname = nicknameTextField.text else { return }
+
+        if nickname.count < 2 {
+            validNicknameLabel.text = "닉네임은 두 글자 이상이어야 합니다."
+            changeButtonStatusAndValidLabel(false)
+        } else {
+            Task { [weak self] in
+                let isPossible = try await FirebaseManager.shared.isPossibleNickname(newName: nickname)
+                self?.validNicknameLabel.text = isPossible ? "사용 가능한 닉네임입니다." : "다른 사용자가 사용 중인 닉네임입니다."
+                self?.changeButtonStatusAndValidLabel(isPossible)
+            }
+        }
+    }
+    
+    private func changeButtonStatusAndValidLabel(_ isPossible: Bool) {
+        validNicknameLabel.textColor = isPossible ? .vfGreen : .vfRed
+        nextButton.isEnabled = isPossible
     }
     
     private func configureTextCountLabel(textLength: Int) {

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -64,9 +64,9 @@ final class UserProfileViewController: UIViewController {
         return textField
     }()
     
-    private let validImageLabel: UILabel = {
-        let label = UILabel()
-        return label
+    private let validImageView: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
     }()
     
     private let validLabel: UILabel = {
@@ -111,7 +111,7 @@ final class UserProfileViewController: UIViewController {
         view.backgroundColor = .systemBackground
         view.addSubviews(progressBarImageView, profileMessageLabel, profileImageView,
                          nicknameMessageLabel, cameraButton, nicknameTextField,
-                         validImageLabel, validLabel, nicknameTextCountLabel, nextButton)
+                         validImageView, validLabel, nicknameTextCountLabel, nextButton)
     }
     
     private func setupLayout() {
@@ -154,8 +154,8 @@ final class UserProfileViewController: UIViewController {
         ])
         
         NSLayoutConstraint.activate([
-            validImageLabel.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 8.5),
-            validImageLabel.leadingAnchor.constraint(equalTo: nicknameTextField.leadingAnchor),
+            validImageView.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 10),
+            validImageView.leadingAnchor.constraint(equalTo: nicknameTextField.leadingAnchor),
         ])
         
         NSLayoutConstraint.activate([
@@ -235,9 +235,7 @@ final class UserProfileViewController: UIViewController {
         let imageSize = CGSize(width: 15, height: 15)
         let textColor = isPossible ? UIColor.vfGreen : UIColor.vfRed
         
-        let SFSymbolToText = NSTextAttachment()
-        SFSymbolToText.image = UIImage(systemName: (isPossible ? "checkmark.circle.fill" : "exclamationmark.circle.fill"))?.withTintColor(textColor).resize(to: imageSize)
-        validImageLabel.attributedText = NSAttributedString(attachment: SFSymbolToText)
+        validImageView.image = UIImage(systemName: (isPossible ? "checkmark.circle.fill" : "exclamationmark.circle.fill"))?.withTintColor(textColor).resize(to: imageSize)
     
         validLabel.text = text
         validLabel.textColor = textColor

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -221,13 +221,11 @@ extension UserProfileViewController: UITextFieldDelegate {
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        print("begin")
-        configureTextField(lineColor: .vfYellow1)
+        textField.underlined(color: .vfYellow1)
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        print("end")
-        configureTextField(lineColor: .vfGray4)
+        textField.underlined(color: .vfGray4)
     }
 }
 

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -60,6 +60,7 @@ final class UserProfileViewController: UIViewController {
         let textField = UITextField()
         textField.borderStyle = .none
         textField.delegate = self
+        textField.clearButtonMode = .always
         textField.addTarget(self, action: #selector(textDidChangeForLabel), for: .editingChanged)
         return textField
     }()

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -198,7 +198,6 @@ final class UserProfileViewController: UIViewController {
     
     @objc
     private func textDidChangeForLabel() {
-        print("textDidChangeForLabel")
         guard let text = nicknameTextField.text else { return }
         var textLength = text.count
         

--- a/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/UserProfileViewController.swift
@@ -90,7 +90,7 @@ final class UserProfileViewController: UIViewController {
         setupLayout()
     }
     
-    func configureTextField() {
+    private func configureTextField() {
         let border = CALayer()
         border.frame = CGRect(x: 0, y: nicknameTextField.frame.size.height-1,
                               width: nicknameTextField.frame.width, height: 1)
@@ -101,14 +101,14 @@ final class UserProfileViewController: UIViewController {
         nicknameTextField.addTarget(self, action: #selector(textDidChangeForLabel), for: .editingChanged)
     }
     
-    func configureUI() {
+    private func configureUI() {
         view.backgroundColor = .systemBackground
         view.addSubviews(progressBarImageView, profileMessageLabel, profileImageView,
                          nicknameMessageLabel, cameraButton, nicknameTextField,
                          nicknameTextCountLabel, nextButton)
     }
     
-    func setupLayout() {
+    private func setupLayout() {
         NSLayoutConstraint.activate([
             progressBarImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: view.frame.height * 1/10),
             progressBarImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),

--- a/Vegeting/Screens/Report/Cell/ReportTableViewCell.swift
+++ b/Vegeting/Screens/Report/Cell/ReportTableViewCell.swift
@@ -103,6 +103,10 @@ final class ReportTableViewCell: UITableViewCell {
         reportLabel.text = reportText
     }
     
+    func readOtherContent() -> String {
+        return contentTextView.text
+    }
+    
     private func setupLayoutTextView() {
         stackView.addArrangedSubviews(contentTextView, contentWordsCountLabel)
         contentTextView.constraint(leading: stackView.leadingAnchor,

--- a/Vegeting/Screens/Report/ViewController/ReportViewController.swift
+++ b/Vegeting/Screens/Report/ViewController/ReportViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 extension UIViewController {
     
     struct ReportStringLiteral {
+        let title: String
         let buttonTitle: String
         let alertTitle: String
         let alertMessage: String
@@ -26,19 +27,22 @@ extension UIViewController {
             switch self {
                 
             case .report:
-                return ReportStringLiteral(buttonTitle: "신고합니다",
+                return ReportStringLiteral(title: "게시물 신고",
+                                           buttonTitle: "신고합니다",
                                            alertTitle: "신고하시겠습니까?",
                                            alertMessage: "신고해주신 내용이 운영팀에 전달됩니다.",
                                            headerTitle: "신고 사유 (최대 3개 선택)",
                                            reportElementList: ["모집글 성격과 맞지 않아요.", "불쾌감을 줍니다.", "개인정보 노출 문제가 있어요", "연애/19+ 만남을 유도합니다.", "법적인 문제가 있어요", "욕설/혐오/차별적 표현이 있습니다.", "음란물입니다.", "불쾌한 표현이 있습니다.", "홍보/도배글입니다.", "기타 (직접 입력)"])
             case .block:
-                return ReportStringLiteral(buttonTitle: "차단합니다",
+                return ReportStringLiteral(title: "사용자 차단",
+                                           buttonTitle: "차단합니다",
                                            alertTitle: "차단하시겠습니까?",
                                            alertMessage: "차단한 사용자의 게시글이 노출되지 않습니다.",
                                            headerTitle: "‘초보채식인'\n사용자를 차단하는 이유가 무언인가요?",
                                            reportElementList: ["불쾌감을 줍니다.", "개인정보를 유출합니다.", "욕설/혐오/차별적 표현을사용해요", "다른 목적을 가지고 접근하는 것 같아요", "불쾌한 표현을 사용해요", "홍보/도배글을 작성합니다.", "기타 (직접 입력)" ])
             case .unregister:
-                return ReportStringLiteral(buttonTitle: "회원 탈퇴",
+                return ReportStringLiteral(title: "회원 탈퇴",
+                                           buttonTitle: "회원 탈퇴",
                                            alertTitle: "탈퇴하시겠습니까?",
                                            alertMessage: "더 이상 해당 계정으로 로그인할 수 없습니다.",
                                            headerTitle: "탈퇴 사유 (최대 3개 선택)",
@@ -102,6 +106,7 @@ final class ReportViewController: UIViewController {
         setupButtonTitle()
         setupLayout()
         configureUI()
+        setupNavigationBar()
         hideKeyboardWhenTappedAround()
     }
     
@@ -115,6 +120,10 @@ final class ReportViewController: UIViewController {
         let buttonTitle = reportType.stringLiteral.buttonTitle
         
         reportButton.setTitle(buttonTitle, for: .normal)
+    }
+    
+    private func setupNavigationBar() {
+        self.navigationItem.title = reportType.stringLiteral.title
     }
     
     private func setupLayout() {

--- a/Vegeting/Screens/Report/ViewController/ReportViewController.swift
+++ b/Vegeting/Screens/Report/ViewController/ReportViewController.swift
@@ -110,6 +110,11 @@ final class ReportViewController: UIViewController {
         hideKeyboardWhenTappedAround()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        hideTabBar()
+    }
+    
     deinit {
         selectedElementList.removeAll()
     }

--- a/Vegeting/Screens/Report/ViewController/ReportViewController.swift
+++ b/Vegeting/Screens/Report/ViewController/ReportViewController.swift
@@ -197,7 +197,7 @@ final class ReportViewController: UIViewController {
         let alert = UIAlertController(title: "탈퇴되었습니다.", message: "서비스를 사용하려면 다시 가입해주세요.", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
             let signInViewController = SignInViewController()
-            self.navigationController?.setViewControllers([signInViewController], animated: false)
+            self.navigationController?.setViewControllers([signInViewController], animated: true)
         }))
         present(alert, animated: true)
     }

--- a/Vegeting/Screens/Report/ViewController/ReportViewController.swift
+++ b/Vegeting/Screens/Report/ViewController/ReportViewController.swift
@@ -173,6 +173,11 @@ final class ReportViewController: UIViewController {
             break
         case .unregister:
             FirebaseManager.shared.unregisterUser(reason: selectedElementList)
+            makeAlert(title: "탈퇴되었습니다", message: "", completion: {
+                let signInViewController = SignInViewController()
+                signInViewController.modalPresentationStyle = .fullScreen
+                self.present(signInViewController, animated: false, completion: nil)
+            })
         }
         
     }

--- a/Vegeting/Screens/Report/ViewController/ReportViewController.swift
+++ b/Vegeting/Screens/Report/ViewController/ReportViewController.swift
@@ -155,11 +155,24 @@ final class ReportViewController: UIViewController {
     }
     
     private func registerReport() {
+        // 기타 옵션이 체크되어 있으면 selectedElementList의 해당 내용을 작성한 내용으로 바꿔주기
         if selectedElementList.contains(StringLiteral.reportTableViewCellTextViewOtherOption) {
-            // TODO: reportButton 확인 시 firebase에 데이터 추가 & 차단, 탈퇴, 신고에 따라 분기처리
-            
-            let index = reportType.stringLiteral.reportElementList.count - 1
-            tableView.cellForRow(at: IndexPath(row: index, section: 0))
+            let cellIndex = reportType.stringLiteral.reportElementList.count - 1
+            guard let otherOptionCell = tableView.cellForRow(at: IndexPath(row: cellIndex, section: 0)) as? ReportTableViewCell else { return }
+            let otherContent = otherOptionCell.readOtherContent()
+            guard let contentIndex = selectedElementList.firstIndex(of: StringLiteral.reportTableViewCellTextViewOtherOption) else { return }
+            selectedElementList[contentIndex] = otherContent
+        }
+        
+        switch reportType {
+        case .report:
+            // TODO: 신고하기 눌렀을때
+            break
+        case .block:
+            // TODO: 차단하기 눌렀을때
+            break
+        case .unregister:
+            FirebaseManager.shared.unregisterUser(reason: selectedElementList)
         }
         
     }

--- a/Vegeting/Screens/Report/ViewController/ReportViewController.swift
+++ b/Vegeting/Screens/Report/ViewController/ReportViewController.swift
@@ -172,14 +172,20 @@ final class ReportViewController: UIViewController {
             // TODO: 차단하기 눌렀을때
             break
         case .unregister:
-            FirebaseManager.shared.unregisterUser(reason: selectedElementList)
-            makeAlert(title: "탈퇴되었습니다", message: "", completion: {
-                let signInViewController = SignInViewController()
-                signInViewController.modalPresentationStyle = .fullScreen
-                self.present(signInViewController, animated: false, completion: nil)
-            })
+            unregister()
         }
         
+    }
+    
+    private func unregister() {
+        FirebaseManager.shared.unregisterUser(reason: selectedElementList)
+        
+        let alert = UIAlertController(title: "탈퇴되었습니다.", message: "서비스를 사용하려면 다시 가입해주세요.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
+            let signInViewController = SignInViewController()
+            self.navigationController?.setViewControllers([signInViewController], animated: false)
+        }))
+        present(alert, animated: true)
     }
     
     private func observeKeyboardWillShow() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #181 
- close #182 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🌱 구현/변경 사항 및 이유
### 1. 닉네임 중복체크 
`validateNickname` 메소드를 작성해 입력한 닉네임이
> 1. 두 글자 이상인지
> 2. 중복이 되는지

확인해 상태에 맞는 라벨 텍스트와 컬러를 적용하고, 버튼 isEnabled를 수정합니다. 


<img width="240" alt="스크린샷 2022-11-30 오후 1 52 12" src="https://user-images.githubusercontent.com/80809782/204710505-d7a00df2-90e2-42fc-8eb5-69a6a3b11fae.png"><img width="240" alt="스크린샷 2022-11-30 오후 1 52 35" src="https://user-images.githubusercontent.com/80809782/204710545-1d776e4e-53f9-4756-aaf6-55ef7c31321e.png"><img width="240" alt="스크린샷 2022-11-30 오후 1 52 22" src="https://user-images.githubusercontent.com/80809782/204710520-19107f18-4ff2-42d0-8f4d-c4c1f9cafbdd.png">

### 2. 닉네임 입력하는 텍스트 필드 밑줄
밑줄이 그어져 있고, 편집중엔 노란 컬러가 적용되어야 해서
```swift
func underlined(color: UIColor)
```
 텍스트필드 익스텐션을 작성해 주었고 
UITextField 델리게이트 함수, beginEditing 과 endEditing 에서 컬러에 맞게 `underlined`을 적용해주었습니다.
(+편집하다 키보드 밖 화면 누르면 키보드 숨기기)

### 3. 회원탈퇴 플로우 연결
1. 먼저 리포트뷰컨으로 이동합니다. 
2. 사용자가 탈퇴사유를 선택한 뒤, 탈퇴하기 버튼을 클리하면
3. 선택된 사유들을 넘겨 회원탈퇴 api를 호출합니다.
4. 탈퇴되었다는 alert 메세지를 띄워주고 
5. 로그인 화면으로 이동

### 4. 회원탈퇴 api 작성
```swift
func unregisterUser(reason: [String])
```
회원탈퇴시 
1. 해당 유저가 선택한 탈퇴 사유를 서버에 저장해줍니다.
2. firseStore에 저장된 해당 유저 정보를 삭제
4. authentication에서 현재 유저 삭제
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🌱 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🌱 참고 사항
<img width="240" alt="스크린샷 2022-11-30 오후 1 52 12" src="https://user-images.githubusercontent.com/80809782/204712841-deb1f208-4601-4bea-bab7-8d40e951b5d8.gif"><img width="240" alt="스크린샷 2022-11-30 오후 1 52 12" src="https://user-images.githubusercontent.com/80809782/204712887-edfda366-3407-4d65-8371-0269b2ff6d01.gif">

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
