### PR TITLE
[FEAT]: 채팅방의 안읽은 메세지 개수 보여주기

### DIFF
--- a/Vegeting/Global/Manager/FirebaseManager.swift
+++ b/Vegeting/Global/Manager/FirebaseManager.swift
@@ -254,6 +254,7 @@ extension FirebaseManager {
     /// 채팅방에서 유저가 마지막으로 읽은 Index 업데이트
     func updateLastReadIndex(user: VFUser, participatedChatRoom: ParticipatedChatRoom, index: Int) async throws {
         guard let chatID = participatedChatRoom.chatID else { return }
+        if let lastReadIndex = participatedChatRoom.lastReadIndex, lastReadIndex >= index { return }
         let updatedParticipatedChatRoom = user.participatedChats?.map({ chatRoom in
             if chatID == chatRoom.chatID {
                 return ParticipatedChatRoom(chatID: chatRoom.chatID, chatName: chatRoom.chatName, imageURL: chatRoom.imageURL, lastReadIndex: index)

--- a/Vegeting/Global/Models/RecentChat.swift
+++ b/Vegeting/Global/Models/RecentChat.swift
@@ -16,4 +16,5 @@ struct RecentChat: Codable, Identifiable {
     let lastSentMessage: String?
     let lastSentTime: Date?
     let coverImageURL: String?
+    let messagesCount: Int?
 }

--- a/Vegeting/Global/Models/VFUser.swift
+++ b/Vegeting/Global/Models/VFUser.swift
@@ -25,6 +25,7 @@ struct ParticipatedChatRoom: Hashable, Codable {
     let chatID: String?
     let chatName: String
     let imageURL: String?
+    let lastReadIndex: Int?
 }
 
 struct ParticipatedClub: Hashable, Codable {

--- a/Vegeting/Screens/ChatRoom/Cell/ChatRoomTableViewCell.swift
+++ b/Vegeting/Screens/ChatRoom/Cell/ChatRoomTableViewCell.swift
@@ -139,7 +139,7 @@ class ChatRoomTableViewCell: UITableViewCell {
         currentUserCountLabel.text = data.currentNumer.description
         latestChatLabel.text = data.latestChat
         latestChatDateLabel.text = convertDate(lastChatDate: data.latestChatDate)
-        unreadChatCountLabel.text = data.unreadChatCount.description
+        unreadChatCountLabel.text = data.unreadChatCount?.description
     }
 
     private func convertDate(lastChatDate: Date) -> String {

--- a/Vegeting/Screens/ChatRoom/ViewController/ChatRoomListViewController.swift
+++ b/Vegeting/Screens/ChatRoom/ViewController/ChatRoomListViewController.swift
@@ -85,13 +85,8 @@ class ChatRoomListViewController: UIViewController {
     
     private func bind() {
         guard let user = user else { return }
-        var lastReadIndexInChatRoom: [String: Int] = [:]
         
-        user.participatedChats?.forEach {
-            if let chatID = $0.chatID, let lastReadIndex = $0.lastReadIndex {
-                lastReadIndexInChatRoom.updateValue(lastReadIndex, forKey: chatID)
-            }
-        }
+        var lastReadIndexInChatRoom = calculateUnreadCountInChat(participatedChats: user.participatedChats)
         
         FirebaseManager.shared.requestRecentChat(user: user) { [weak self] result in
             switch result {
@@ -110,6 +105,20 @@ class ChatRoomListViewController: UIViewController {
             }
         }
     }
+    
+    /// 참여한 채팅방에 마지막으로 읽은 Index를 알려주는 Dictionary
+    private func calculateUnreadCountInChat(participatedChats: [ParticipatedChatRoom]?) -> [String: Int] {
+        var result = [String: Int]()
+        guard let participatedChats = participatedChats else { return result }
+        participatedChats.forEach {
+            if let chatID = $0.chatID, let lastReadIndex = $0.lastReadIndex {
+                result.updateValue(lastReadIndex, forKey: chatID)
+            }
+        }
+        return result
+    }
+    
+    ///  안읽은 메세지 수 계산(채팅방 메시지 - 해당 유저가 마지막으로 읽은 index)
     private func calculateUnreadMessage(messagesCount: Int?, lastReadIndexByUser: Int?) -> Int {
         if let messagesCount = messagesCount, let lastReadIndexByUser = lastReadIndexByUser {
             return messagesCount - lastReadIndexByUser

--- a/Vegeting/Screens/ChatRoom/ViewController/ChatRoomListViewController.swift
+++ b/Vegeting/Screens/ChatRoom/ViewController/ChatRoomListViewController.swift
@@ -121,7 +121,7 @@ class ChatRoomListViewController: UIViewController {
     ///  안읽은 메세지 수 계산(채팅방 메시지 - 해당 유저가 마지막으로 읽은 index)
     private func calculateUnreadMessage(messagesCount: Int?, lastReadIndexByUser: Int?) -> Int {
         if let messagesCount = messagesCount, let lastReadIndexByUser = lastReadIndexByUser {
-            return messagesCount - lastReadIndexByUser
+            return (messagesCount - 1) - lastReadIndexByUser
         } else {
             return 0
         }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #189 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
## 🌱 구현/변경 사항 및 이유
### Model 수정
1. RecentChat Model에 저장된 채팅 메세지들의 개수 field추가 
2. ParticipatedChatRoom에는 내가 해당 채팅방에서 읽은 마지막 index 추가

### FirebaseManager 마지막으로 읽은 index 업데이트
1. updateLastReadIndex 함수
해당 함수는, User문서에 참여한 채팅방의 마지막 index를 업데이트 하기 위한 함수
VFUser에서 participatedChatRoom이 수정된 새로운 user데이터인 newUser를 Firebase에 update해줍니다. 

### ChatRoomListViewController
1. calculateUnreadCountInChat 
해당 함수는 참여한 채팅방들의 ID를 입력하면 마지막으로 안읽은 index를 알려주는 Dictionary를 리턴합니다.

2. calculateUnreadMessage
해당 함수는 let unreadCount = (해당 채팅방의 메세지 Count - 1) - lastReadIndexByUser를 통해서 안읽은 메세지의 개수를 카운트합니다.
## 🌱 PR Point
1. 현재 User를 새로운 User로 바꾸는 방식으로 구현했습니다. 해당 participatedChatRoom field만 update방식으로 바꾸고 싶은데, 쉽지가 않아서, 아시는 분들 있으면 도움 부탁드려요!
2. calculateUnreadCountInChat를 통해서 chatID만 있으면 마지막으로 읽은 index를 알려주는 Dictionary를 사용하는 목적이 이해가 잘 되사나요?

## 🌱 참고 사항
<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
![image](https://user-images.githubusercontent.com/39371835/205547943-72c00c1d-f1ed-4ffa-8616-78101b987e98.png)

