### PR TITLE
[TESTFLIGHT] 프로필 설정 네번째 뷰에서 textview를 keyboard가 가리는 오류 해결

### DIFF
--- a/Vegeting/Screens/RegisterUserProfile/ViewController/FourthTypeIntroductionViewController.swift
+++ b/Vegeting/Screens/RegisterUserProfile/ViewController/FourthTypeIntroductionViewController.swift
@@ -95,6 +95,7 @@ final class FourthTypeIntroductionViewController: UIViewController {
         configureUI()
         hideKeyboardWhenTappedAround()
         setupLayout()
+        observeKeyboardWillShow()
     }
     
     private func configureTextView() {
@@ -193,6 +194,22 @@ final class FourthTypeIntroductionViewController: UIViewController {
         guard let type = vegetarianTypeSelectButton.currentTitle else { return }
         let userTypeIntroduction = FourthTypeIntroduction(userGenderBirthYear: userGenderBirthYear, userVegetarianType: type, userIntroduction: introductionTextView.text)
         navigationController?.pushViewController(FifthInterestViewController(userTypeIntroduction: userTypeIntroduction), animated: true)
+    }
+    
+    private func observeKeyboardWillShow() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(scrollVerticalWhenKeybaordWillShow),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+    }
+    
+    @objc
+    private func scrollVerticalWhenKeybaordWillShow(notification: NSNotification) {
+        let scrollHeightToBottom = scrollView.contentSize.height - scrollView.bounds.size.height
+        if scrollHeightToBottom > 0 {
+            let scrollHeightToBottomOffset = CGPoint(x: 0, y: scrollHeightToBottom)
+            scrollView.setContentOffset(scrollHeightToBottomOffset, animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- #202 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🌱 구현/변경 사항 및 이유
- 키보드가 나타나면 NotificationCenter를 통해 이를 감지하는 observeKeyboardWillShow() 함수를 통해 scrollVerticalWhenKeybaordWillShow() 함수가 실행됩니다.
- scrollVerticalWhenKeybaordWillShow() 함수는 키보드 높이만큼 스크롤뷰를 위로 올려주는 기능을 합니다.
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🌱 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🌱 참고 사항
<img src="https://user-images.githubusercontent.com/96123303/206623538-e0a20828-6ebf-4655-b206-19dcf781bba3.png" width=300/>

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
